### PR TITLE
feat: Add image generation for tarot readings

### DIFF
--- a/backend-php/public/index.php
+++ b/backend-php/public/index.php
@@ -45,6 +45,11 @@ switch ($route) {
             $controller->pregunta();
         }
         break;
+    case 'tarot/createImage':
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            $controller->createImage();
+        }
+        break;
     default:
         header("HTTP/1.0 404 Not Found");
         echo json_encode(['error' => 'Endpoint no encontrado']);


### PR DESCRIPTION
- Adds a new endpoint /api/tarot/createImage to generate an image based on a user's question and selected tarot cards.

- Uses the gemini-2.5-flash-image-preview model to generate the image.

- The response contains the image in base64 format.